### PR TITLE
minor HomeScreen checks, SnapLines for art

### DIFF
--- a/gallery_wall_planner/gui/HomeScreen.py
+++ b/gallery_wall_planner/gui/HomeScreen.py
@@ -1,5 +1,8 @@
+
+
 #!/usr/bin/env python3
 import tkinter as tk
+import os
 
 def on_new():
     print("New button pressed")
@@ -75,15 +78,36 @@ def on_load():
 def on_quit():
     root.quit()
 
+try:
+    resample_filter = Image.Resampling.LANCZOS  # Pillow ≥ 9.1.0
+except AttributeError:
+    resample_filter = Image.ANTIALIAS  # Older versions
+
 def resize_background(event):
-    # Resize the original image to the current window size
-    new_width = event.width
-    new_height = event.height
-    resized = original_image.resize((new_width, new_height), Image.ANTIALIAS)
-    # Update the PhotoImage and the label displaying it
-    bg_image = ImageTk.PhotoImage(resized)
-    background_label.config(image=bg_image)
-    background_label.image = bg_image  # Keep a reference!
+    if original_image is not None:
+        try:
+            # Resize the original image to the current window size
+            new_width = event.width
+            new_height = event.height
+            resized = original_image.resize((new_width, new_height), resample_filter)
+            # Update the PhotoImage and the label displaying it
+            bg_image = ImageTk.PhotoImage(resized)
+            background_label.config(image=bg_image)
+            background_label.image = bg_image  # Keep a reference!
+        except Exception as e:
+            print(f"Error resizing background image: {e}")
+
+def resize_background(event):
+    if original_image is not None:
+        new_width = max(event.width, 1)
+        new_height = max(event.height, 1)
+        try:
+            resized = original_image.resize((new_width, new_height), resample_filter)
+            bg_image = ImageTk.PhotoImage(resized)
+            background_label.config(image=bg_image)
+            background_label.image = bg_image  # prevent garbage collection
+        except Exception as e:
+            print(f"[Warning] Failed to resize background: {e}")
 
 # Create the main window
 root = tk.Tk()
@@ -91,7 +115,9 @@ root.title("Gallery Wall Planner")
 root.geometry("600x400")  # initial size
 
 # Load the background image (hard-coded to GalleryWall.png)
-original_image = Image.open("GalleryWall.png")
+original_image = None
+if os.path.exists("GalleryWall.png"):
+    original_image = Image.open("GalleryWall.png")
 
 # Create a label to display the background image and fill the entire window.
 background_label = tk.Label(root)
@@ -138,3 +164,6 @@ container.lift()
 
 # Start the main event loop
 root.mainloop()
+
+
+

--- a/gallery_wall_planner/gui/snap_line_popup.py
+++ b/gallery_wall_planner/gui/snap_line_popup.py
@@ -1,0 +1,89 @@
+import tkinter as tk
+from tkinter import ttk, messagebox, Toplevel
+from gallery_wall_planner.models.wall_line import SingleLine
+from gallery_wall_planner.gui.ui_styles import apply_primary_button_style
+
+def open_snap_line_popup(root, on_save_callback, existing_line=None, wall_width=100, wall_height=100):
+    popup = Toplevel(root)
+    popup.title("Add Snap Line" if existing_line is None else "Edit Snap Line")
+    popup.geometry("300x320")
+
+    # Orientation Radio Buttons
+    orientation_var = tk.StringVar(value=existing_line.orientation if existing_line else "horizontal")
+    ttk.Label(popup, text="Orientation:").pack(anchor="w", padx=10, pady=(10, 0))
+    ttk.Radiobutton(popup, text="Horizontal", variable=orientation_var, value="horizontal").pack(anchor="w", padx=20)
+    ttk.Radiobutton(popup, text="Vertical", variable=orientation_var, value="vertical").pack(anchor="w", padx=20)
+
+    # Alignment Radio Buttons
+    alignment_var = tk.StringVar(value=existing_line.alignment if existing_line else "center")
+    alignment_frame = ttk.Frame(popup)
+    alignment_frame.pack(anchor="w", padx=10, pady=(10, 0))
+
+    ttk.Label(alignment_frame, text="Alignment:").pack(anchor="w")
+
+    align_options = {
+        "horizontal": ["top", "center", "bottom"],
+        "vertical": ["left", "center", "right"]
+    }
+
+    align_buttons = []
+
+    def update_alignment_buttons():
+        for btn in align_buttons:
+            btn.destroy()
+        align_buttons.clear()
+
+        current = orientation_var.get()
+        for val in align_options[current]:
+            b = ttk.Radiobutton(alignment_frame, text=val.capitalize(), variable=alignment_var, value=val)
+            b.pack(anchor="w", padx=20)
+            align_buttons.append(b)
+
+    orientation_var.trace_add("write", lambda *_: update_alignment_buttons())
+    update_alignment_buttons()
+
+    # Distance Entry
+    ttk.Label(popup, text="Distance (inches):").pack(anchor="w", padx=10, pady=(10, 0))
+    distance_var = tk.DoubleVar(value=existing_line.distance if existing_line else 0.0)
+    distance_entry = ttk.Entry(popup, textvariable=distance_var)
+    distance_entry.pack(padx=10, fill="x")
+
+    # Save Button
+    def save():
+        try:
+            distance = float(distance_var.get())
+        except ValueError:
+            messagebox.showerror("Invalid Input", "Distance must be a number.")
+            return
+        
+        # After parsing the float we need to use info from the wall to make sure these can not be placed out of bounds:
+        if distance < 0:
+            messagebox.showerror("Error", "Distance cannot be negative.")
+            return
+
+        if orientation_var.get() == "horizontal" and distance > wall_height:
+            messagebox.showerror("Error", f"Distance exceeds wall height ({wall_height} inches).")
+            return
+
+        if orientation_var.get() == "vertical" and distance > wall_width:
+            messagebox.showerror("Error", f"Distance exceeds wall width ({wall_width} inches).")
+            return
+
+        updated_line = SingleLine(
+            orientation=orientation_var.get(),
+            alignment=alignment_var.get(),
+            distance=distance,
+            snap_to=True,
+            moveable=True
+        )
+
+        popup.destroy()
+        on_save_callback(updated_line)
+
+    save_btn = ttk.Button(popup, text="Save", command=save)
+    apply_primary_button_style(save_btn)
+    save_btn.pack(pady=10)
+
+    popup.transient(root)
+    popup.grab_set()
+    popup.wait_window()

--- a/gallery_wall_planner/models/wall_line.py
+++ b/gallery_wall_planner/models/wall_line.py
@@ -2,7 +2,7 @@ import json
 from types import SimpleNamespace
 
 class WallLine:
-    def __init__(self, x = 0, y = 0, length = 0, angle = 0, snap_to = False, moveable = True):
+    def __init__(self, x=0, y=0, length=0, angle=0, snap_to=False, moveable=True):
         self.x_cord = x
         self.y_cord = y
         self.length = length
@@ -11,11 +11,38 @@ class WallLine:
         self.moveable = moveable
 
     def export_wall_line(self):
-        #Temp way to export object to json, can be refined later
-        return(json.dumps(self.__dict__))
+        return json.dumps(self.__dict__)
 
-def import_wall_line(wall_line_name, file_name):
-    #TEMP: Replace later with the menu input
-    with open(file_name, "rb") as f:
+
+class SingleLine:
+    def __init__(
+        self,
+        x=0,
+        y=0,
+        length=0,
+        angle=0,
+        snap_to=True,
+        moveable=True,
+        orientation="horizontal",  # "horizontal" or "vertical"
+        alignment="center",        # Alignment point on artwork
+        distance=0.0               # Distance from wall edge (in inches)
+    ):
+        self.x_cord = x
+        self.y_cord = y
+        self.length = length
+        self.angle = angle
+        self.snap_to = snap_to
+        self.moveable = moveable
+        self.orientation = orientation
+        self.alignment = alignment
+        self.distance = distance
+
+    def export_snap_line(self):
+        return json.dumps(self.__dict__)
+
+
+def import_wall_line(file_name):
+    """Import a wall line object from JSON file."""
+    with open(file_name, "r") as f:
         data = f.read()
-    wall_line_name = json.loads(data, object_hook=lambda d: SimpleNamespace(**d))
+    return json.loads(data, object_hook=lambda d: SimpleNamespace(**d))


### PR DESCRIPTION
Deprecated, but not universally updated:
resized = original_image.resize((new_width, new_height), Image.ANTIALIAS) replaced with:
try:
    resample_filter = Image.Resampling.LANCZOS  # Pillow ≥ 9.1.0
except AttributeError:
    resample_filter = Image.ANTIALIAS  # Older versions
resized = original_image.resize((new_width, new_height), resample_filter)

Ensure no risk of crash if image not present and try in case image resize has issue during window movement: original_image = None
if os.path.exists("GalleryWall.png"):
    original_image = Image.open("GalleryWall.png")
def resize_background(event):
    if original_image is not None:
        new_width = max(event.width, 1)
        new_height = max(event.height, 1)
        try:
            resized = original_image.resize((new_width, new_height), resample_filter)
            bg_image = ImageTk.PhotoImage(resized)
            background_label.config(image=bg_image)
            background_label.image = bg_image  # prevent garbage collection
        except Exception as e:
            print(f"[Warning] Failed to resize background: {e}")

Added snap-to line logic to OrganizeArt.py
snap_line_popup.py created to help with this.
Center snapping line at 62inches comes in automatically. GUI ability to create additional lines as long as they do not go outside the wall. User warned if lines are at the same location, but allowed since one might be a top line and the other a center line. GUI ability to edit/delete snap lines.
Sides of wall respected over snap lines, so no risk of artwork looking like it will fit, but actually go beyond outer wall.