### PR TITLE
Fix negative values within models

### DIFF
--- a/gallery_wall_planner/gui/screen_new_gallery_ui.py
+++ b/gallery_wall_planner/gui/screen_new_gallery_ui.py
@@ -265,6 +265,15 @@ class ScreenNewGalleryUI(ScreenBase):
 
         canvas_width = 400
         canvas_height = 300
+        if wall_width == 0 or wall_height == 0:
+            raise ValueError("Error: Wall dimensions must be positive")
+        if wall_width < 0:
+            wall_width = abs(wall_width)
+            print("Wall width must be positive, defaulting to positive value")
+        if wall_height < 0:
+            wall_height = abs(wall_height)
+            print("Wall height must be positive, defaulting to positive value")
+        
         ratio = min(canvas_width / wall_width, canvas_height / wall_height)
         scaled_width = wall_width * ratio
         scaled_height = wall_height * ratio

--- a/gallery_wall_planner/models/artwork.py
+++ b/gallery_wall_planner/models/artwork.py
@@ -50,6 +50,10 @@ class Artwork(WallObject):
     @height.setter
     def height(self, value: float):
         """Set the artwork's height with validation"""
+        if not isinstance(value, (int,float)):
+            raise ValueError("height must be a number")
+        if value <= 0:
+            raise ValueError("Height must be a positive value")
         self._height = float(value) if value is not None else 0.0
     
     @property


### PR DESCRIPTION
So, the models actually seem to handle negative number by just defaulting to the absolute value of the negative number. I added in some error handling for the screen_new_gallery.py to do something similar to what automatically happens for the models. We may be ok with just leaving the models as is, but I wasn't certain. 